### PR TITLE
More graceful connection and disconnecting

### DIFF
--- a/client.py
+++ b/client.py
@@ -156,7 +156,12 @@ def draw_game_over():
 #connect to server, blocks till game starts
 def connect(address, port):
     global gameStarted, playerNumber
-    sock.connect((address, port))
+
+    try:
+        sock.connect((address, port))
+    except:
+        print("Failed to connect to server")
+        return -1
 
     draw_waiting_screen()
 


### PR DESCRIPTION
- Added try-catch on client side for when they fail to connect to server, gives readable error message
- Server now prints readable log message when client leaves mid-game instead of "Error occurred during broadcast ..."
- Fixed an issue where if all clients left the game early and then joined again to start a new one, they would have to wait until the previous game finished before a new one started. A new game will now immediately start if all clients leave and then join the server.